### PR TITLE
Docker image based upon alpine and reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN chmod +x /opt/goEDMS/goEDMS && \
 # Stage 2
 FROM scratch
 COPY --from=build / /
+LABEL Author="deranjer"
+LABEL name="goEDMS"
 EXPOSE 8000
 WORKDIR /opt/goEDMS
 ENTRYPOINT [ "/opt/goEDMS/goEDMS" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM alpine:latest as build
 LABEL Author="deranjer"
 LABEL name="goEDMS"
-EXPOSE 8000
 RUN mkdir -p /opt/goEDMS/public/built && \
   mkdir /opt/goEDMS/config && \
   adduser -S goEDMS && addgroup -S goEDMS
@@ -17,6 +16,8 @@ RUN chmod +x /opt/goEDMS/goEDMS && \
 # Stage 2
 FROM scratch
 COPY --from=build / /
+EXPOSE 8000
+WORKDIR /opt/goEDMS
 ENTRYPOINT [ "/opt/goEDMS/goEDMS" ]
 
 #docker build -t deranjer/goedms:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Stage 1
 FROM alpine:latest as build
-LABEL Author="deranjer"
-LABEL name="goEDMS"
 RUN mkdir -p /opt/goEDMS/public/built && \
   mkdir /opt/goEDMS/config && \
   adduser -S goEDMS && addgroup -S goEDMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM debian:latest
+# Stage 1
+FROM alpine:latest as build
 LABEL Author="deranjer"
 LABEL name="goEDMS"
 EXPOSE 8000
-RUN mkdir /opt/goEDMS
-RUN mkdir -p /opt/goEDMS/public/built
-RUN mkdir /opt/goEDMS/config
-RUN useradd goEDMS
+RUN mkdir -p /opt/goEDMS/public/built && \
+  mkdir /opt/goEDMS/config && \
+  adduser -S goEDMS && addgroup -S goEDMS
 WORKDIR /opt/goEDMS
-COPY LICENSE /opt/goEDMS/config/LICENSE
-COPY README.md /opt/goEDMS/config/README.md
+COPY LICENSE README.md /opt/goEDMS/config/
 COPY public/built/* /opt/goEDMS/public/built/
 COPY dist/goEDMS_linux_amd64/goEDMS /opt/goEDMS/goEDMS
-RUN chmod +x /opt/goEDMS/goEDMS
-RUN chown -R goEDMS:goEDMS /opt/goEDMS/
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get -y install imagemagick tesseract-ocr
+RUN chmod +x /opt/goEDMS/goEDMS && \
+  chown -R goEDMS:goEDMS /opt/goEDMS/ && \
+  apk update && apk add imagemagick tesseract-ocr
+
+# Stage 2
+FROM scratch
+COPY --from=build / /
 ENTRYPOINT [ "/opt/goEDMS/goEDMS" ]
 
 #docker build -t deranjer/goedms:latest .


### PR DESCRIPTION
I've rebased the docker image upon alpine and did a multi stage build. This leads to a smaller docker image:

> $ docker image ls | grep -i goedms
madic                                   goedms-multi               229d28918242        4 seconds ago       222MB
deranjer/goedms                         latest                     57ab44848742        16 hours ago        410MB